### PR TITLE
FIX README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,91 +2,90 @@ Visual Inspection Api for C#
 ===
 *[English](README.md) | [日本語](README.ja.md)*
 
-ハカルスはメーカーとメディカル事業に向けて軽量と解釈できるAIソリューションズを提供しています。
+ハカルスはメーカーとメディカル事業に向け、軽量で説明可能なAIソリューションズを提供しています。
 
-私たちの技術はスパースモデリングに基づいて、人間のようにデータを理解でき、独特な特徴である機械学習手法である。スパースモデリングの軽量のデザインのおかげで、コンピューティングパワー、クラウド接続、および可用性のある学習データの資源制限環境に特に有用である。 
+私たちのスパースモデリングに基づいた技術は、人間のようにデータを理解できる独自の機械学習手法です。スパースモデリングは軽量に設計されているため、コンピューティングパワー、クラウド環境、および少量の学習データなどの資源の制限された環境下で特に有用です。
 
-私たちのソリューションズは組み込みシステムでオフラインの環境かクラウドモジュールとして実行できます。伝統的なDLベースの侵入よりも、私たちははるかに多くリソース効率的で、よりよく結果を確保できます。
+私たちのソリューションズは組み込みシステムでオフライン環境かクラウドで実行できます。伝統的なDLベースの手法に比べ、資源を効率的に使用し、よりよい結果を提供します。
 
-ハカルスの外観検査ソリューションの詳細を参照するには、こちらのリンク、https://hacarus.com/visual-inspection/ をご覧になってください。または、APIのアクセスリクエストはinquiry@hacarus.comまで連絡してください。
+ハカルスの外観検査ソリューションの詳細を参照するには、こちらのリンク、https://hacarus.com/visual-inspection/ をご覧ください。また、APIへのアクセスのリクエストはinquiry@hacarus.comまでご連絡ください。
 
-この外観検査 Api wrapper for C#はapi通して外観検査モジュールを統合したいソフトウエアエンジニアに向けて、wrapperはC#ベースのアプリケーションSupports .Net Framework 4.6.1 and .Net Core 2.0.メソッドコールの簡単な統合を提供しています。
+この外観検査 API wrapper for C#はあなたのC#のプロジェクトに、このAPI通して外観検査モジュールを組み込むことができます。このライブラリはC# .Net Framework 4.6.1 と.Net Core 2.0.をサポートしています。
 
 
 - [インストール](#インストール)
-- [条項](#条項)
-- [使用法](#使用法)
+- [用語説明](#用語説明)
+- [使用方法](#使用方法)
   * [1. 初期化](#1-初期化)
-  * [2. 承認する](#2-承認する)
-  * [3. ライセンスをアクティベート](#3-ライセンスをアクティベート)
-  * [4. データを入手する](#4-データを入手する)
-  * [5. アルゴリズムを入手する](#5-アルゴリズムを入手する)
-  * [6. モデルを入手する](#6-モデルを入手する)
+  * [2. 認証](#2-認証)
+  * [3. ライセンスのアクティベート](#3-ライセンスのアクティベート)
+  * [4. データを取得する](#4-データを取得する)
+  * [5. アルゴリズムを取得する](#5-アルゴリズムを取得する)
+  * [6. モデルを取得する](#6-モデルを取得する)
   * [7. 学習](#7-学習)
   * [8. データを追加する](#8-データを追加する)
-  * [9. 特定のデータを入手](#9-特定のデータを入手)
+  * [9. 特定のデータを取得する](#9-特定のデータを取得する)
   * [10. 予測](#10-予測)
 - [一般的なエラー](#一般的なエラー)
 
 ## インストール
-このパッケージをプロジェクトにインストールするため、こちらのコマンドをPackage Manager Consoleに使用してください。
+このパッケージをプロジェクトにインストールするため、こちらのコマンドをPackage Manager Consoleに入力してください。
 
 
 ```
 PM> Install-Package HacarusVisualInspectionApi -Version 1.0.0-beta
 ```
 
-これを「Add packages」を使用してプロジェクトに追加し、Show prerelease packagesを確認して、 HacarusVisualInspectionApi を [nuget.org](nuget.org)のリポジトリで検索してください。
+NuGetパッケージマネージャを使用してプロジェクトに追加することもできます。Show prerelease packagesにチェックを入れ、 HacarusVisualInspectionApi を [nuget.org](nuget.org)のリポジトリで検索してください。
 
 
-他のインストール選択は[Nuget Package Site](https://www.nuget.org/packages/HacarusVisualInspectionApi/1.0.0-beta)にあります。
+他のインストール方法は[Nuget Package Site](https://www.nuget.org/packages/HacarusVisualInspectionApi/1.0.0-beta)を参照ください。
 
-## 用語
+## 用語説明
 このドキュメントの全体で使用されている用語の簡単な説明：
 
 **モデル**
-モデルは一連のパラメータの設定とともに、データセットの学習データ（トレーニングデータとも呼ばれる）をアルゴリズムに適用して、作成できます（または、学習できます）。
+モデルは一連のパラメータの設定とともに、データセットの学習データ（トレーニングデータ）をアルゴリズムに適用して、作成・学習できます。
 
 
 **アルゴリズム**
-アルゴリズムはモデルを構成するため使われている機械学習コード　－　外観検査作業の性質と予想される精度および性能によって選択されます。
+アルゴリズムはモデルを構成するため使用する機械学習アルゴリズムのことです。外観検査の性質と予想される精度および性能によって選択します。
 
 
 **学習**
-新しいモデルを制作することのプロセスである。
+新しいモデルを作成する操作です。
 
 **パラメータ**
-パラメータは、学習中にアルゴリズムを適用する方法を構成するために使用されます。 例えば、最小または最大受けられる画像解像度などに適用できます。
-
+パラメータは、学習中にアルゴリズムを適用する方法を構成するために使用されます。 例えば、最小または最大の画像解像度などがあります。
 
 **データ**
-データ（アイテムとも呼ばれる)は検査の対象となる単一のプロダクトのデータを表します。 1つのデータに1つまたは複数の画像を関連付けることができます。
-例：倉庫内の梱包箱。6つの箱の各側面に6つの画像があります。
+データ（アイテムとも呼ばれる)は検査の対象となる単一の製品のデータを表します。 1つのデータに1つまたは複数の画像を関連付けることができます。
+例：倉庫内の梱包箱の場合、一つの箱に6つの面の画像があります。
 
 ## 使用方法
 
-#### 1. 初期設定
+#### 1. 初期化
 
 ```csharp
 using HacarusVisualInspectionApi;
+using HacarusVisualInspectionApi.Models;
 HacarusVisualInspection visualInspection = new HacarusVisualInspection("https://yourserverurl.com/api");
 ```
 
 - ライブラリを初期化します
-- エンドポイントURLをパラメータとして使用
-- エンドポイントが使用されていない場合、ライブラリはデフォルトのエンドポイントhttps://sdd.hacarus.com/apiを使用します。
+- エンドポイントURLを引数として入力
+- エンドポイントが入力されていない場合、ライブラリはデフォルトのエンドポイントhttps://sdd.hacarus.com/apiを使用します。
 - 個別のエンドポイントURLは、リクエストに応じてHacarusから提供されます。
 
 
 #### 2. 認証
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 AccessTokenResponse response = visualInspection.Authorize(YourClientId, YourClientSecret);
 ```
 
 - アクセストークンを生成します
-- クライアントIDとクライアントシークレットをパラメータとして使用する
+- クライアントIDとクライアントシークレットを引数として入力する
 - クライアントIDとクライアントシークレットは、リクエストに応じてHacarusから提供されます。
 
 
@@ -103,7 +102,7 @@ AccessTokenResponse response = visualInspection.Authorize(YourClientId, YourClie
 
 ##### 起こり得るエラー
 
-- `401 Unauthorized`: クライエントIDは無効
+- `401 Unauthorized`: クライアントIDが無効です
 
 ```json
 {
@@ -133,17 +132,16 @@ AccessTokenResponse response = visualInspection.Authorize(YourClientId, YourClie
 }
 ```
 
-#### 3. ライセンスをアクティベートする
+#### 3. ライセンスのアクティベート
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
-UploadResponse response = hacarusVisualInspection.ActivateLicense(customerId, licenseFile);
+UploadResponse response = visualInspection.ActivateLicense(licenseFile, customerId);
 ```
 
-- ライセンスをアクティベート
-- カスタマーIDとライセンスファイル両方ともパラメータとして追加してください。
-- ライセンスはユーザーが`Train` または `Predict`というファンクションを使用できる前にアクティベートしてください。
-- ライセンスファイルを得るため、ハカルスを連絡してください。
+- ライセンスをアクティベートします
+- ライセンスファイルとカスタマーIDを引数として入力してください。
+- ライセンスはユーザーが`Train` または `Predict`というファンクションを使用する前にアクティベートしてください。
+- ライセンスファイルを取得するには、ハカルスにご連絡ください。
 
 
 
@@ -176,11 +174,10 @@ UploadResponse response = hacarusVisualInspection.ActivateLicense(customerId, li
 #### 4. データを取得する
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 ItemsResponse response = visualInspection.GetItems();
 ```
 
-- 学習、推論、およびアーカイブ別に分類したアップロード済みアイテムのリストを取得します。
+- 学習、推論、およびアーカイブ別に分類したアップロード済みアイテムの一覧をリストを取得します。
     - `training`: 学習に使用するデータ
         - データが`true`（good）、`false`（defect）、または`null`（ラベルなし）のいずれかにラベル付けされているかをgoodというキーで知ることができます。
     - `predict`: アップロード済みのデータのうち、推論用のもの
@@ -234,14 +231,13 @@ ItemsResponse response = visualInspection.GetItems();
 }
 ```
     
-#### 5. アルゴリズムの一覧を取得
+#### 5. アルゴリズムを取得する
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 AlgorithmResponse response = visualInspection.GetAlgorithms();
 ```
 
-- 学習に使用できるアルゴリズムと使用できるパラメータをリストで返します
+- 学習に使用できるアルゴリズムと使用できるパラメータの一覧をリストで返します
 
 ##### レスポンスの一例
 
@@ -294,14 +290,13 @@ AlgorithmResponse response = visualInspection.GetAlgorithms();
 }
 ```
     
-#### 6. モデルの一覧を取得
+#### 6. モデルを取得する
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 ModelsResponse response = visualInspection.GetModels();
 ```
 
-- データを予測するのに使用できる作成済みモデルのリストを取得します
+- データを予測するのに使用できる作成済みモデルの一覧をリストを取得します
 - モデルIDが渡されなかった場合（`Serve`メソッドを使用して）、`active`が`true`のモデルをデフォルトとして使用します。
 - `status`キーは、モデルが`active`か`failed`かを示します。 
     - `status`が `active`のモデルは正常に作成され、予測に使用できます
@@ -329,7 +324,6 @@ ModelsResponse response = visualInspection.GetModels();
 #### 7. 学習
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 //ID of the algorithm you want to use
 var algorithmId = "hacarus-dictionary-learning";
 //Name of your model
@@ -341,7 +335,7 @@ AlgorithmParameter algorithmParameter = new AlgorithmParameter();
 algorithmParameter.algorithm_parameter_id = 221;
 algorithmParameter.value = "50";
 
-ModelRootObject reponse = visualInspection.Train(algorithmId, modelName, itemIds, new AlgorithmParameter[] { algorithmParameter });
+ModelResponse reponse = visualInspection.Train(algorithmId, modelName, itemIds, new AlgorithmParameter[] { algorithmParameter });
 ```
 
 - 予測に使用するモデルを作成します
@@ -389,7 +383,6 @@ ModelRootObject reponse = visualInspection.Train(algorithmId, modelName, itemIds
 #### 8. データを追加する
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 UploadResponse response = visualInspection.Upload(filenames, isGood, isTraining);
 ```
 
@@ -451,12 +444,11 @@ UploadResponse response = visualInspection.Upload(filenames, isGood, isTraining)
 #### 9. 特定のデータを取得する
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 //Set a specific itemId to get detailed information about the item
 ItemResponse response = visualInspection.GetItem(itemId);
 ```
 
-- データIDで特定のデータを取得する
+- データIDで特定のデータを取得します。
 - データIDは、アップロード時に画像ファイル名に基づいて割り当てられます。
 - 重要なキー:
     - `computed_assessment`: 予測の結果
@@ -565,7 +557,6 @@ ItemResponse response = visualInspection.GetItem(itemId);
 #### 10. 予測
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 //Use itemIds to pass an array of item ids you want to set for prediction
 //You may use a specific model for prediction by setting a modelId value. This is optional. IF not set, the active/default model will be used.
 PredictResponse response = visualInspection.Serve(itemIds, modelId);
@@ -620,7 +611,7 @@ PredictResponse response = visualInspection.Serve(itemIds, modelId);
 ```
 
 ##  一般的なエラー
-- メソッドを呼び出すときにまだ承認されていないエラーが出ました。エラーを遭遇する場合、最初に`Authorize`メソッドを呼び出してください。
+- メソッドを呼び出すときにまだ承認されていないエラーです。エラーを遭遇する場合、最初に`Authorize`メソッドを呼び出してください。
 
 ```json
 {
@@ -635,7 +626,7 @@ PredictResponse response = visualInspection.Serve(itemIds, modelId);
 }
 ```
 
-- メソッドを呼び出すが、ライセンスがまだアクティベートされていないか期限切れになっているときのエラー。 遭遇したら、最初に`ActivateLicense`メソッドを呼び出してください。
+- メソッドを呼び出すが、ライセンスがまだアクティベートされていないか期限切れになっているときのエラーです。 遭遇したら、最初に`ActivateLicense`メソッドを呼び出してください。
 
     ```json
     {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For example: A packaging box in a storage warehouse, with 6 images for each of t
 
 ```csharp
 using HacarusVisualInspectionApi;
+using HacarusVisualInspectionApi.Models;
 HacarusVisualInspection visualInspection = new HacarusVisualInspection("https://yourserverurl.com/api");
 ```
 
@@ -76,7 +77,6 @@ HacarusVisualInspection visualInspection = new HacarusVisualInspection("https://
 #### 2. Authorize
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 AccessTokenResponse response = visualInspection.Authorize(YourClientId, YourClientSecret);
 ```
 
@@ -130,8 +130,7 @@ AccessTokenResponse response = visualInspection.Authorize(YourClientId, YourClie
 #### 3. Activate License
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
-UploadResponse response = hacarusVisualInspection.ActivateLicense(customerId, licenseFile);
+UploadResponse response = visualInspection.ActivateLicense(licenseFile, customerId);
 ```
 
 - Activates the license
@@ -168,7 +167,6 @@ UploadResponse response = hacarusVisualInspection.ActivateLicense(customerId, li
 #### 4. Get Items
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 ItemsResponse response = visualInspection.GetItems();
 ```
 
@@ -229,7 +227,6 @@ ItemsResponse response = visualInspection.GetItems();
 #### 5. Get Algorithms
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 AlgorithmResponse response = visualInspection.GetAlgorithms();
 ```
 
@@ -289,7 +286,6 @@ AlgorithmResponse response = visualInspection.GetAlgorithms();
 #### 6. Get Models
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 ModelsResponse response = visualInspection.GetModels();
 ```
 
@@ -321,7 +317,6 @@ ModelsResponse response = visualInspection.GetModels();
 #### 7. Train
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 //ID of the algorithm you want to use
 var algorithmId = "hacarus-dictionary-learning";
 //Name of your model
@@ -333,7 +328,7 @@ AlgorithmParameter algorithmParameter = new AlgorithmParameter();
 algorithmParameter.algorithm_parameter_id = 221;
 algorithmParameter.value = "50";
 
-ModelRootObject reponse = visualInspection.Train(algorithmId, modelName, itemIds, new AlgorithmParameter[] { algorithmParameter });
+ModelResponse reponse = visualInspection.Train(algorithmId, modelName, itemIds, new AlgorithmParameter[] { algorithmParameter });
 ```
 
 - Creates model to use for prediction
@@ -381,7 +376,6 @@ ModelRootObject reponse = visualInspection.Train(algorithmId, modelName, itemIds
 #### 8. Add Item
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 UploadResponse response = visualInspection.Upload(filenames, isGood, isTraining);
 ```
 
@@ -443,7 +437,6 @@ UploadResponse response = visualInspection.Upload(filenames, isGood, isTraining)
 #### 9. Get Specific Item
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 //Set a specific itemId to get detailed information about the item
 ItemResponse response = visualInspection.GetItem(itemId);
 ```
@@ -557,7 +550,6 @@ ItemResponse response = visualInspection.GetItem(itemId);
 #### 10. Predict
 
 ```csharp
-using HacarusVisualInspectionApi.Models;
 //Use itemIds to pass an array of item ids you want to set for prediction
 //You may use a specific model for prediction by setting a modelId value. This is optional. IF not set, the active/default model will be used.
 PredictResponse response = visualInspection.Serve(itemIds, modelId);


### PR DESCRIPTION
"using HacarusVisualInspectionApi.Models" should be included in initialize.
In Activate License, licenseFile and customerId has been reversed.
hacarusVisualInspection is wrong. It has been declared visualInspection.
ModelRootObject is wrong. It is ModelResponse.
